### PR TITLE
Remove use of Typstry.jl internals

### DIFF
--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -52,7 +52,7 @@ function Makie.convert_text_string!(outputs::NamedTuple, input_text::TypstString
     return nothing
 end
 
-Makie.iswhitespace(l::TypstString) = Makie.iswhitespace(replace(l.text, '$' => ""))
+Makie.iswhitespace(l::TypstString) = Makie.iswhitespace(replace(l, '$' => ""))
 
 @testitem "iswhitespace" begin
     using Typstry


### PR DESCRIPTION
Hi! This is an awesome project, and I'm excited to see where it goes from here :rocket: Let me know if you have any questions or find any limitations in Typstry.jl :)

Small nit: the basic string interface works out of the box. Some related functionality may be missing, but may be added in the future.

```julia-repl
julia> replace(typst"", '$' => "")
""

julia> replace(typst"$$", '$' => "")
""

julia> replace(typst"$a+3/x$", '$' => "")
"a+3/x"
```